### PR TITLE
Show some pure text body in notification when keyword not found

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -231,7 +231,11 @@ class Monitor extends BeanModel {
                             bean.msg += ", keyword is found";
                             bean.status = UP;
                         } else {
-                            throw new Error(bean.msg + ", but keyword is not found");
+                            data = data.replace(/<[^>]*>?|[\n\r]|\s+/gm, " ");
+                            if ( data.length > 50 ) {
+                                data = data.substring(0, 47) + "...";
+                            }
+                            throw new Error(bean.msg + ", but keyword is not in [ " + data + " ]");
                         }
 
                     }

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -235,7 +235,7 @@ class Monitor extends BeanModel {
                             if ( data.length > 50 ) {
                                 data = data.substring(0, 47) + "...";
                             }
-                            throw new Error(bean.msg + ", but keyword is not in [ " + data + " ]");
+                            throw new Error(bean.msg + ", but keyword is not in [" + data + "]");
                         }
 
                     }

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -232,7 +232,7 @@ class Monitor extends BeanModel {
                             bean.status = UP;
                         } else {
                             data = data.replace(/<[^>]*>?|[\n\r]|\s+/gm, " ");
-                            if ( data.length > 50 ) {
+                            if (data.length > 50) {
                                 data = data.substring(0, 47) + "...";
                             }
                             throw new Error(bean.msg + ", but keyword is not in [" + data + "]");


### PR DESCRIPTION
Add first 50 characters from response body to bean.msg when keyword not match.

Description

- Fixes https://github.com/louislam/uptime-kuma/issues/1201. As the issue mentions before, when keyword not found in response, I'd like to add some response body into notification and database. This may be minimum modification of exists code, only effect when http keyword type and keyword not found in response. I also truncate body in first 50 characters after remove HTML tags and line breaks.